### PR TITLE
Fix convertibility for dfix with distinct systems.

### DIFF
--- a/Eval.hs
+++ b/Eval.hs
@@ -1154,7 +1154,7 @@ instance Convertible Val where
       (VNext l k v, VNext l' k' v')      -> k == k' && conv ns (v `swap` (l,lf)) (v' `swap` (l',lf))
       (VNext l k v, u'            )      -> conv ns v              (delBind l u')
       (u          , VNext l' k' v')      -> conv ns (delBind l' u) v'
-      (VDFix k a f _, VDFix k' a' f' _)  -> k == k' && conv ns (a,f) (a',f')
+      (VDFix k a f s, VDFix k' a' f' s') -> k == k' && conv ns (a,f,s) (a',f',s')
       (VPrev k v, VPrev k' v')           -> conv ns (v `swap` (k,kf)) (v' `swap` (k',kf))
       (VCLam k v, VCLam k' v')           -> conv ns (v `swap` (k,kf)) (v' `swap` (k',kf))
       (VCLam k v, v')                    -> conv ns (v `swap` (k,kf)) (v' `appk` kf)

--- a/gctt-examples/streams.ctt
+++ b/gctt-examples/streams.ctt
@@ -21,8 +21,8 @@ foldStr (s : |> Str) : |> [S <- dfix U StrF] S
 
 foldunfoldStr (s : StrPath @ 0)
  : Id (|> [S <- dfix U StrF] S) s (foldStr (unfoldStr s))
- = <j> comp (<i> StrPath @ -i)
-            (comp StrPath
+ = <j> comp (<i> StrPath @ -i /\ j)
+            (comp (<i> StrPath @ i /\ j)
                   s
                   [(j=0) -> <_> s])
             [(j=0) -> <_> s]


### PR DESCRIPTION
Two `dfix` values that only differ by their systems are distinct because
they won't unfold in the same conditions.
